### PR TITLE
Convert /contact to components v2

### DIFF
--- a/src/commands/contact.command.ts
+++ b/src/commands/contact.command.ts
@@ -1,7 +1,7 @@
 import type { Command } from "../models";
 import { buildContactEmbed } from "../utils/build-contact-embed";
 import { logError } from "../utils/logger";
-import {MessageFlags} from "discord.js";
+import { MessageFlags } from "discord.js";
 
 const contactCommand: Command = {
   name: "contact",

--- a/src/commands/contact.command.ts
+++ b/src/commands/contact.command.ts
@@ -1,6 +1,7 @@
 import type { Command } from "../models";
 import { buildContactEmbed } from "../utils/build-contact-embed";
 import { logError } from "../utils/logger";
+import {MessageFlags} from "discord.js";
 
 const contactCommand: Command = {
   name: "contact",
@@ -14,7 +15,7 @@ const contactCommand: Command = {
 
     try {
       await message.react("\u{1F4E7}");
-      await message.reply({ embeds: [embed] });
+      await message.reply({ components: [embed], flags: MessageFlags.IsComponentsV2 });
     } catch (error) {
       logError(error, {
         event: "contact_command_react_error",
@@ -22,7 +23,7 @@ const contactCommand: Command = {
         guildId: message.guildId,
         channelId: message.channelId,
       });
-      await message.reply({ embeds: [embed] });
+      await message.reply({ components: [embed], flags: MessageFlags.IsComponentsV2 });
     }
   },
 };

--- a/src/slash-commands/contact.command.ts
+++ b/src/slash-commands/contact.command.ts
@@ -1,4 +1,4 @@
-import { SlashCommandBuilder } from "discord.js";
+import {MessageFlags, SlashCommandBuilder} from "discord.js";
 
 import type { SlashCommand } from "../models";
 import { buildContactEmbed } from "../utils/build-contact-embed";
@@ -13,7 +13,7 @@ const contactSlashCommand: SlashCommand = {
   async execute(interaction, _client) {
     const embed = buildContactEmbed();
 
-    await interaction.reply({ embeds: [embed] });
+    await interaction.reply({ components: [embed], flags: [MessageFlags.IsComponentsV2, MessageFlags.Ephemeral] });
   },
 };
 

--- a/src/slash-commands/contact.command.ts
+++ b/src/slash-commands/contact.command.ts
@@ -1,4 +1,4 @@
-import {MessageFlags, SlashCommandBuilder} from "discord.js";
+import { MessageFlags, SlashCommandBuilder } from "discord.js";
 
 import type { SlashCommand } from "../models";
 import { buildContactEmbed } from "../utils/build-contact-embed";
@@ -13,7 +13,10 @@ const contactSlashCommand: SlashCommand = {
   async execute(interaction, _client) {
     const embed = buildContactEmbed();
 
-    await interaction.reply({ components: [embed], flags: [MessageFlags.IsComponentsV2, MessageFlags.Ephemeral] });
+    await interaction.reply({
+      components: [embed],
+      flags: [MessageFlags.IsComponentsV2, MessageFlags.Ephemeral],
+    });
   },
 };
 

--- a/src/utils/build-contact-embed.ts
+++ b/src/utils/build-contact-embed.ts
@@ -98,10 +98,10 @@ export const buildContactEmbed = (): ContainerBuilder => {
         .addTextDisplayComponents(
           new TextDisplayBuilder().setContent(
             "## :e_mail: WritingTeam\n" +
-              "- Submitting a Play This Set, Wish This Set, or RAdvantage entry.\n" +
-              "- Submitting a retrogaming article.\n" +
-              "- Proposing a new article idea.\n" +
-              "- Getting involved with RANews.",
+              "- Reporting achievements with grammatical mistakes.\n" +
+              "- Reporting achievements with unclear or confusing descriptions.\n" +
+              "- Requesting help from the team with proofreading achievement sets.\n" +
+              "- Requesting help for coming up with original titles for achievements."
           ),
         ),
     )

--- a/src/utils/build-contact-embed.ts
+++ b/src/utils/build-contact-embed.ts
@@ -1,77 +1,145 @@
-import { EmbedBuilder } from "discord.js";
+import {COLORS} from "../config/constants";
+import {
+    TextDisplayBuilder,
+    SeparatorBuilder,
+    SeparatorSpacingSize,
+    ButtonBuilder,
+    ButtonStyle,
+    SectionBuilder,
+    ContainerBuilder
+} from 'discord.js';
 
-import { COLORS } from "../config/constants";
+const buildContactButton = (account: string): ButtonBuilder => {
+    return new ButtonBuilder()
+        .setStyle(ButtonStyle.Link)
+        .setLabel("Message " + account)
+        .setURL("https://retroachievements.org/messages/create?to=" + account);
+}
 
-export const buildContactEmbed = (): EmbedBuilder => {
-  return new EmbedBuilder()
-    .setColor(COLORS.PRIMARY)
-    .setTitle("Contact Us")
-    .setDescription(
-      "If you would like to contact us, please send a site message to the appropriate team below.",
-    )
-    .addFields([
-      {
-        name: ":e_mail: Admins and Moderators",
-        value: `[Send a message to RAdmin](https://retroachievements.org/createmessage.php?t=RAdmin)
-                 - Reporting offensive behavior.
-                 - Reporting copyrighted material.
-                 - Requesting to be untracked.`,
-      },
-      {
-        name: ":e_mail: Developer Compliance",
-        value: `[Send a message to Developer Compliance](https://retroachievements.org/createmessage.php?t=DevCompliance)
-                 - Requesting set approval or early set release.
-                 - Reporting achievements or sets with unwelcome concepts.
-                 - Reporting sets failing to cover basic progression.`,
-      },
-      {
-        name: ":e_mail: Quality Assurance",
-        value: `[Send a message to Quality Assurance](https://retroachievements.org/createmessage.php?t=QATeam)
-                 - Reporting a broken set, leaderboard, or rich presence.
-                 - Reporting achievements with grammatical mistakes.
-                 - Requesting a set be playtested.
-                 - Hash compatibility questions.
-                 - Hub organizational questions.
-                 - Getting involved in a QA sub-team.`,
-      },
-      {
-        name: ":e_mail: RAArtTeam",
-        value: `[Send a message to RAArtTeam](https://retroachievements.org/messages/create?to=RAArtTeam)
-                 - Icon Gauntlets and how to start one.
-                 - Proposing art updates.
-                 - Questions about art-related rule changes.
-                 - Requests for help with creating a new badge or badge set.`,
-      },
-      {
-        name: ":e_mail: WritingTeam",
-        value: `[Send a message to WritingTeam](https://retroachievements.org/messages/create?to=WritingTeam)
-                 - Reporting achievements with grammatical mistakes.
-                 - Reporting achievements with unclear or confusing descriptions.
-                 - Requesting help from the team with proofreading achievement sets.
-                 - Requesting help for coming up with original titles for achievements.`,
-      },
-      {
-        name: ":e_mail: RANews",
-        value: `[Send a message to RANews](https://retroachievements.org/createmessage.php?t=RANews)
-                 - Submitting a Play This Set, Wish This Set, or RAdvantage entry.
-                 - Submitting a retrogaming article.
-                 - Proposing a new article idea.
-                 - Getting involved with RANews.`,
-      },
-      {
-        name: ":e_mail: RAEvents",
-        value: `[Send a message to RAEvents](https://retroachievements.org/createmessage.php?t=RAEvents)
-                 - Submissions, questions, ideas, or reporting issues related to events.`,
-      },
-      {
-        name: ":e_mail: DevQuest",
-        value: `[Send a message to DevQuest](https://retroachievements.org/createmessage.php?t=DevQuest)
-                 - Submissions, questions, ideas, or reporting issues related to DevQuest.`,
-      },
-      {
-        name: ":e_mail: RACheats",
-        value: `[Send a message to RACheats](https://retroachievements.org/createmessage.php?t=RACheats)
-                 - If you believe someone is in violation of our [Global Leaderboard and Achievement Hunting Rules](https://docs.retroachievements.org/guidelines/users/global-leaderboard-and-achievement-hunting-rules.html#not-allowed).`,
-      },
-    ]);
+export const buildContactEmbed = (): ContainerBuilder => {
+    return new ContainerBuilder()
+        .setAccentColor(COLORS.PRIMARY)
+        .addTextDisplayComponents(
+            new TextDisplayBuilder().setContent("# Contact Us\n" +
+                "If you would like to contact us, please send a site message to the appropriate team below."),
+        )
+        .addSeparatorComponents(
+            new SeparatorBuilder().setSpacing(SeparatorSpacingSize.Small).setDivider(true),
+        )
+        .addSectionComponents(
+            new SectionBuilder()
+                .setButtonAccessory(
+                    buildContactButton("RAdmin")
+                )
+                .addTextDisplayComponents(
+                    new TextDisplayBuilder().setContent("## :e_mail: Admins and Moderators\n" +
+                        "- Reporting offensive behavior.\n" +
+                        "- Reporting copyrighted material.\n" +
+                        "- Requesting to be untracked."),
+                ),
+        )
+        .addSeparatorComponents(
+            new SeparatorBuilder().setSpacing(SeparatorSpacingSize.Small).setDivider(true),
+        )
+        .addSectionComponents(
+            new SectionBuilder()
+                .setButtonAccessory(
+                    buildContactButton("DevCompliance")
+                )
+                .addTextDisplayComponents(
+                    new TextDisplayBuilder().setContent("## :e_mail: Developer Compliance\n" +
+                        "- Requesting set approval or early set release.\n" +
+                        "- Reporting achievements or sets with unwelcome concepts.\n" +
+                        "- Reporting sets failing to cover basic progression."),
+                ),
+        )
+        .addSeparatorComponents(
+            new SeparatorBuilder().setSpacing(SeparatorSpacingSize.Small).setDivider(true),
+        )
+        .addSectionComponents(
+            new SectionBuilder()
+                .setButtonAccessory(
+                    buildContactButton("QATeam")
+                )
+                .addTextDisplayComponents(
+                    new TextDisplayBuilder().setContent("## :e_mail: Quality Assurance\n" +
+                        "- Reporting a broken set, leaderboard, or rich presence.\n" +
+                        "- Reporting achievements with grammatical mistakes.\n" +
+                        "- Requesting a set be playtested.\n" +
+                        "- Hash compatibility questions.\n" +
+                        "- Hub organizational questions.\n" +
+                        "- Getting involved in a QA sub-team."),
+                ),
+        )
+        .addSeparatorComponents(
+            new SeparatorBuilder().setSpacing(SeparatorSpacingSize.Small).setDivider(true),
+        )
+        .addSectionComponents(
+            new SectionBuilder()
+                .setButtonAccessory(
+                    buildContactButton("RAArtTeam")
+                )
+                .addTextDisplayComponents(
+                    new TextDisplayBuilder().setContent("## :e_mail: RAArtTeam\n" +
+                        "- Icon Gauntlets and how to start one.\n" +
+                        "- Proposing art updates.\n" +
+                        "- Questions about art-related rule changes.\n" +
+                        "- Requests for help with creating a new badge or badge set."),
+                ),
+        )
+        .addSeparatorComponents(
+            new SeparatorBuilder().setSpacing(SeparatorSpacingSize.Small).setDivider(true),
+        )
+        .addSectionComponents(
+            new SectionBuilder()
+                .setButtonAccessory(
+                    buildContactButton("WritingTeam")
+                )
+                .addTextDisplayComponents(
+                    new TextDisplayBuilder().setContent("## :e_mail: WritingTeam\n" +
+                        "- Submitting a Play This Set, Wish This Set, or RAdvantage entry.\n" +
+                        "- Submitting a retrogaming article.\n" +
+                        "- Proposing a new article idea.\n" +
+                        "- Getting involved with RANews."),
+                ),
+        )
+        .addSeparatorComponents(
+            new SeparatorBuilder().setSpacing(SeparatorSpacingSize.Small).setDivider(true),
+        )
+        .addSectionComponents(
+            new SectionBuilder()
+                .setButtonAccessory(
+                    buildContactButton("RAEvents")
+                )
+                .addTextDisplayComponents(
+                    new TextDisplayBuilder().setContent("## :e_mail: RAEvents\n" +
+                        "- Submissions, questions, ideas, or reporting issues related to events."),
+                ),
+        )
+        .addSeparatorComponents(
+            new SeparatorBuilder().setSpacing(SeparatorSpacingSize.Small).setDivider(true),
+        )
+        .addSectionComponents(
+            new SectionBuilder()
+                .setButtonAccessory(
+                    buildContactButton("DevQuest")
+                )
+                .addTextDisplayComponents(
+                    new TextDisplayBuilder().setContent("## :e_mail: DevQuest\n" +
+                        "- Submissions, questions, ideas, or reporting issues related to DevQuest."),
+                ),
+        )
+        .addSeparatorComponents(
+            new SeparatorBuilder().setSpacing(SeparatorSpacingSize.Small).setDivider(true),
+        )
+        .addSectionComponents(
+            new SectionBuilder()
+                .setButtonAccessory(
+                    buildContactButton("RACheats")
+                )
+                .addTextDisplayComponents(
+                    new TextDisplayBuilder().setContent("## :e_mail: RACheats\n" +
+                        "- If you believe someone is in violation of our [Global Leaderboard and Achievement Hunting Rules](https://docs.retroachievements.org/guidelines/users/global-leaderboard-and-achievement-hunting-rules.html#not-allowed)."),
+                ),
+        );
 };

--- a/src/utils/build-contact-embed.ts
+++ b/src/utils/build-contact-embed.ts
@@ -1,13 +1,20 @@
 import { COLORS } from "../config/constants";
 import {
-  TextDisplayBuilder,
-  SeparatorBuilder,
-  SeparatorSpacingSize,
   ButtonBuilder,
   ButtonStyle,
-  SectionBuilder,
   ContainerBuilder,
+  SectionBuilder,
+  SeparatorBuilder,
+  SeparatorSpacingSize,
+  TextDisplayBuilder,
 } from "discord.js";
+
+type Team = {
+  name: string;
+  // username to message on RA
+  username: string;
+  reasons: string[];
+};
 
 const buildContactButton = (account: string): ButtonBuilder => {
   return new ButtonBuilder()
@@ -15,6 +22,18 @@ const buildContactButton = (account: string): ButtonBuilder => {
     .setLabel("Message " + account)
     .setURL("https://retroachievements.org/messages/create?to=" + account);
 };
+
+const buildTeamSection = (team: Team): SectionBuilder => {
+  const reasons = team.reasons.map((reason: string) => "- " + reason).join("\n");
+
+  return new SectionBuilder()
+    .setButtonAccessory(buildContactButton(team.username))
+    .addTextDisplayComponents(
+      new TextDisplayBuilder().setContent("## :e_mail: " + team.name + "\n" + reasons),
+    );
+};
+
+const separator = new SeparatorBuilder().setSpacing(SeparatorSpacingSize.Small).setDivider(true);
 
 export const buildContactEmbed = (): ContainerBuilder => {
   return new ContainerBuilder()
@@ -25,139 +44,108 @@ export const buildContactEmbed = (): ContainerBuilder => {
           "If you would like to contact us, please send a site message to the appropriate team below.",
       ),
     )
-    .addSeparatorComponents(
-      new SeparatorBuilder().setSpacing(SeparatorSpacingSize.Small).setDivider(true),
-    )
+    .addSeparatorComponents(separator)
     .addSectionComponents(
-      new SectionBuilder()
-        .setButtonAccessory(buildContactButton("RAdmin"))
-        .addTextDisplayComponents(
-          new TextDisplayBuilder().setContent(
-            "## :e_mail: Admins and Moderators\n" +
-              "- Reporting offensive behavior.\n" +
-              "- Reporting copyrighted material.\n" +
-              "- Requesting to be untracked.",
-          ),
-        ),
+      buildTeamSection({
+        name: "Admins and Moderators",
+        username: "RAdmin",
+        reasons: [
+          "Reporting offensive behavior.",
+          "Reporting copyrighted material.",
+          "Requesting to be untracked.",
+        ],
+      }),
     )
-    .addSeparatorComponents(
-      new SeparatorBuilder().setSpacing(SeparatorSpacingSize.Small).setDivider(true),
-    )
+    .addSeparatorComponents(separator)
     .addSectionComponents(
-      new SectionBuilder()
-        .setButtonAccessory(buildContactButton("DevCompliance"))
-        .addTextDisplayComponents(
-          new TextDisplayBuilder().setContent(
-            "## :e_mail: Developer Compliance\n" +
-              "- Requesting set approval or early set release.\n" +
-              "- Reporting achievements or sets with unwelcome concepts.\n" +
-              "- Reporting sets failing to cover basic progression.",
-          ),
-        ),
+      buildTeamSection({
+        name: "Developer Compliance",
+        username: "DevCompliance",
+        reasons: [
+          "Requesting set approval or early set release.",
+          "Reporting achievements or sets with unwelcome concepts.",
+          "Reporting sets failing to cover basic progression.",
+        ],
+      }),
     )
-    .addSeparatorComponents(
-      new SeparatorBuilder().setSpacing(SeparatorSpacingSize.Small).setDivider(true),
-    )
+    .addSeparatorComponents(separator)
     .addSectionComponents(
-      new SectionBuilder()
-        .setButtonAccessory(buildContactButton("QATeam"))
-        .addTextDisplayComponents(
-          new TextDisplayBuilder().setContent(
-            "## :e_mail: Quality Assurance\n" +
-              "- Reporting a broken set, leaderboard, or rich presence.\n" +
-              "- Reporting achievements with grammatical mistakes.\n" +
-              "- Requesting a set be playtested.\n" +
-              "- Hash compatibility questions.\n" +
-              "- Hub organizational questions.\n" +
-              "- Getting involved in a QA sub-team.",
-          ),
-        ),
+      buildTeamSection({
+        name: "Quality Assurance",
+        username: "QATeam",
+        reasons: [
+          "Reporting a broken set, leaderboard, or rich presence.",
+          "Reporting achievements with grammatical mistakes.",
+          "Requesting a set be playtested.",
+          "Hash compatibility questions.",
+          "Hub organizational questions.",
+          "Getting involved in a QA sub-team.",
+        ],
+      }),
     )
-    .addSeparatorComponents(
-      new SeparatorBuilder().setSpacing(SeparatorSpacingSize.Small).setDivider(true),
-    )
+    .addSeparatorComponents(separator)
     .addSectionComponents(
-      new SectionBuilder()
-        .setButtonAccessory(buildContactButton("RAArtTeam"))
-        .addTextDisplayComponents(
-          new TextDisplayBuilder().setContent(
-            "## :e_mail: RAArtTeam\n" +
-              "- Icon Gauntlets and how to start one.\n" +
-              "- Proposing art updates.\n" +
-              "- Questions about art-related rule changes.\n" +
-              "- Requests for help with creating a new badge or badge set.",
-          ),
-        ),
+      buildTeamSection({
+        name: "Art Team",
+        username: "RAArtTeam",
+        reasons: [
+          "Icon Gauntlets and how to start one.",
+          "Proposing art updates.",
+          "Questions about art-related rule changes.",
+          "Requests for help with creating a new badge or badge set.",
+        ],
+      }),
     )
-    .addSeparatorComponents(
-      new SeparatorBuilder().setSpacing(SeparatorSpacingSize.Small).setDivider(true),
-    )
+    .addSeparatorComponents(separator)
     .addSectionComponents(
-      new SectionBuilder()
-        .setButtonAccessory(buildContactButton("WritingTeam"))
-        .addTextDisplayComponents(
-          new TextDisplayBuilder().setContent(
-            "## :e_mail: WritingTeam\n" +
-              "- Reporting achievements with grammatical mistakes.\n" +
-              "- Reporting achievements with unclear or confusing descriptions.\n" +
-              "- Requesting help from the team with proofreading achievement sets.\n" +
-              "- Requesting help for coming up with original titles for achievements."
-          ),
-        ),
+      buildTeamSection({
+        name: "Writing Team",
+        username: "WritingTeam",
+        reasons: [
+          "Reporting achievements with grammatical mistakes.",
+          "Reporting achievements with unclear or confusing descriptions.",
+          "Requesting help from the team with proofreading achievement sets.",
+          "Requesting help for coming up with original titles for achievements.",
+        ],
+      }),
     )
-    .addSeparatorComponents(
-      new SeparatorBuilder().setSpacing(SeparatorSpacingSize.Small).setDivider(true),
-    )
+    .addSeparatorComponents(separator)
     .addSectionComponents(
-      new SectionBuilder()
-        .setButtonAccessory(buildContactButton("RANews"))
-        .addTextDisplayComponents(
-          new TextDisplayBuilder().setContent(
-            "## :e_mail: RANews\n" +
-              "- Submitting a Play This Set, Wish This Set, or RAdvantage entry.\n" +
-              "- Submitting a retrogaming article.\n" +
-              "- Proposing a new article idea.\n" +
-              "- Getting involved with RANews.",
-          ),
-        ),
+      buildTeamSection({
+        name: "RANews",
+        username: "RANews",
+        reasons: [
+          "Submitting a Play This Set, Wish This Set, or RAdvantage entry.",
+          "Submitting a retrogaming article.",
+          "Proposing a new article idea.",
+          "Getting involved with RANews.",
+        ],
+      }),
     )
-    .addSeparatorComponents(
-      new SeparatorBuilder().setSpacing(SeparatorSpacingSize.Small).setDivider(true),
-    )
+    .addSeparatorComponents(separator)
     .addSectionComponents(
-      new SectionBuilder()
-        .setButtonAccessory(buildContactButton("RAEvents"))
-        .addTextDisplayComponents(
-          new TextDisplayBuilder().setContent(
-            "## :e_mail: RAEvents\n" +
-              "- Submissions, questions, ideas, or reporting issues related to events.",
-          ),
-        ),
+      buildTeamSection({
+        name: "RAEvents",
+        username: "RAEvents",
+        reasons: ["Submissions, questions, ideas, or reporting issues related to events."],
+      }),
     )
-    .addSeparatorComponents(
-      new SeparatorBuilder().setSpacing(SeparatorSpacingSize.Small).setDivider(true),
-    )
+    .addSeparatorComponents(separator)
     .addSectionComponents(
-      new SectionBuilder()
-        .setButtonAccessory(buildContactButton("DevQuest"))
-        .addTextDisplayComponents(
-          new TextDisplayBuilder().setContent(
-            "## :e_mail: DevQuest\n" +
-              "- Submissions, questions, ideas, or reporting issues related to DevQuest.",
-          ),
-        ),
+      buildTeamSection({
+        name: "DevQuest",
+        username: "DevQuest",
+        reasons: ["Submissions, questions, ideas, or reporting issues related to DevQuest."],
+      }),
     )
-    .addSeparatorComponents(
-      new SeparatorBuilder().setSpacing(SeparatorSpacingSize.Small).setDivider(true),
-    )
+    .addSeparatorComponents(separator)
     .addSectionComponents(
-      new SectionBuilder()
-        .setButtonAccessory(buildContactButton("RACheats"))
-        .addTextDisplayComponents(
-          new TextDisplayBuilder().setContent(
-            "## :e_mail: RACheats\n" +
-              "- If you believe someone is in violation of our [Global Leaderboard and Achievement Hunting Rules](https://docs.retroachievements.org/guidelines/users/global-leaderboard-and-achievement-hunting-rules.html#not-allowed).",
-          ),
-        ),
+      buildTeamSection({
+        name: "RACheats",
+        username: "RACheats",
+        reasons: [
+          "If you believe someone is in violation of our [Global Leaderboard and Achievement Hunting Rules](https://docs.retroachievements.org/guidelines/users/global-leaderboard-and-achievement-hunting-rules.html#not-allowed).",
+        ],
+      }),
     );
 };

--- a/src/utils/build-contact-embed.ts
+++ b/src/utils/build-contact-embed.ts
@@ -1,145 +1,163 @@
-import {COLORS} from "../config/constants";
+import { COLORS } from "../config/constants";
 import {
-    TextDisplayBuilder,
-    SeparatorBuilder,
-    SeparatorSpacingSize,
-    ButtonBuilder,
-    ButtonStyle,
-    SectionBuilder,
-    ContainerBuilder
-} from 'discord.js';
+  TextDisplayBuilder,
+  SeparatorBuilder,
+  SeparatorSpacingSize,
+  ButtonBuilder,
+  ButtonStyle,
+  SectionBuilder,
+  ContainerBuilder,
+} from "discord.js";
 
 const buildContactButton = (account: string): ButtonBuilder => {
-    return new ButtonBuilder()
-        .setStyle(ButtonStyle.Link)
-        .setLabel("Message " + account)
-        .setURL("https://retroachievements.org/messages/create?to=" + account);
-}
+  return new ButtonBuilder()
+    .setStyle(ButtonStyle.Link)
+    .setLabel("Message " + account)
+    .setURL("https://retroachievements.org/messages/create?to=" + account);
+};
 
 export const buildContactEmbed = (): ContainerBuilder => {
-    return new ContainerBuilder()
-        .setAccentColor(COLORS.PRIMARY)
+  return new ContainerBuilder()
+    .setAccentColor(COLORS.PRIMARY)
+    .addTextDisplayComponents(
+      new TextDisplayBuilder().setContent(
+        "# Contact Us\n" +
+          "If you would like to contact us, please send a site message to the appropriate team below.",
+      ),
+    )
+    .addSeparatorComponents(
+      new SeparatorBuilder().setSpacing(SeparatorSpacingSize.Small).setDivider(true),
+    )
+    .addSectionComponents(
+      new SectionBuilder()
+        .setButtonAccessory(buildContactButton("RAdmin"))
         .addTextDisplayComponents(
-            new TextDisplayBuilder().setContent("# Contact Us\n" +
-                "If you would like to contact us, please send a site message to the appropriate team below."),
-        )
-        .addSeparatorComponents(
-            new SeparatorBuilder().setSpacing(SeparatorSpacingSize.Small).setDivider(true),
-        )
-        .addSectionComponents(
-            new SectionBuilder()
-                .setButtonAccessory(
-                    buildContactButton("RAdmin")
-                )
-                .addTextDisplayComponents(
-                    new TextDisplayBuilder().setContent("## :e_mail: Admins and Moderators\n" +
-                        "- Reporting offensive behavior.\n" +
-                        "- Reporting copyrighted material.\n" +
-                        "- Requesting to be untracked."),
-                ),
-        )
-        .addSeparatorComponents(
-            new SeparatorBuilder().setSpacing(SeparatorSpacingSize.Small).setDivider(true),
-        )
-        .addSectionComponents(
-            new SectionBuilder()
-                .setButtonAccessory(
-                    buildContactButton("DevCompliance")
-                )
-                .addTextDisplayComponents(
-                    new TextDisplayBuilder().setContent("## :e_mail: Developer Compliance\n" +
-                        "- Requesting set approval or early set release.\n" +
-                        "- Reporting achievements or sets with unwelcome concepts.\n" +
-                        "- Reporting sets failing to cover basic progression."),
-                ),
-        )
-        .addSeparatorComponents(
-            new SeparatorBuilder().setSpacing(SeparatorSpacingSize.Small).setDivider(true),
-        )
-        .addSectionComponents(
-            new SectionBuilder()
-                .setButtonAccessory(
-                    buildContactButton("QATeam")
-                )
-                .addTextDisplayComponents(
-                    new TextDisplayBuilder().setContent("## :e_mail: Quality Assurance\n" +
-                        "- Reporting a broken set, leaderboard, or rich presence.\n" +
-                        "- Reporting achievements with grammatical mistakes.\n" +
-                        "- Requesting a set be playtested.\n" +
-                        "- Hash compatibility questions.\n" +
-                        "- Hub organizational questions.\n" +
-                        "- Getting involved in a QA sub-team."),
-                ),
-        )
-        .addSeparatorComponents(
-            new SeparatorBuilder().setSpacing(SeparatorSpacingSize.Small).setDivider(true),
-        )
-        .addSectionComponents(
-            new SectionBuilder()
-                .setButtonAccessory(
-                    buildContactButton("RAArtTeam")
-                )
-                .addTextDisplayComponents(
-                    new TextDisplayBuilder().setContent("## :e_mail: RAArtTeam\n" +
-                        "- Icon Gauntlets and how to start one.\n" +
-                        "- Proposing art updates.\n" +
-                        "- Questions about art-related rule changes.\n" +
-                        "- Requests for help with creating a new badge or badge set."),
-                ),
-        )
-        .addSeparatorComponents(
-            new SeparatorBuilder().setSpacing(SeparatorSpacingSize.Small).setDivider(true),
-        )
-        .addSectionComponents(
-            new SectionBuilder()
-                .setButtonAccessory(
-                    buildContactButton("WritingTeam")
-                )
-                .addTextDisplayComponents(
-                    new TextDisplayBuilder().setContent("## :e_mail: WritingTeam\n" +
-                        "- Submitting a Play This Set, Wish This Set, or RAdvantage entry.\n" +
-                        "- Submitting a retrogaming article.\n" +
-                        "- Proposing a new article idea.\n" +
-                        "- Getting involved with RANews."),
-                ),
-        )
-        .addSeparatorComponents(
-            new SeparatorBuilder().setSpacing(SeparatorSpacingSize.Small).setDivider(true),
-        )
-        .addSectionComponents(
-            new SectionBuilder()
-                .setButtonAccessory(
-                    buildContactButton("RAEvents")
-                )
-                .addTextDisplayComponents(
-                    new TextDisplayBuilder().setContent("## :e_mail: RAEvents\n" +
-                        "- Submissions, questions, ideas, or reporting issues related to events."),
-                ),
-        )
-        .addSeparatorComponents(
-            new SeparatorBuilder().setSpacing(SeparatorSpacingSize.Small).setDivider(true),
-        )
-        .addSectionComponents(
-            new SectionBuilder()
-                .setButtonAccessory(
-                    buildContactButton("DevQuest")
-                )
-                .addTextDisplayComponents(
-                    new TextDisplayBuilder().setContent("## :e_mail: DevQuest\n" +
-                        "- Submissions, questions, ideas, or reporting issues related to DevQuest."),
-                ),
-        )
-        .addSeparatorComponents(
-            new SeparatorBuilder().setSpacing(SeparatorSpacingSize.Small).setDivider(true),
-        )
-        .addSectionComponents(
-            new SectionBuilder()
-                .setButtonAccessory(
-                    buildContactButton("RACheats")
-                )
-                .addTextDisplayComponents(
-                    new TextDisplayBuilder().setContent("## :e_mail: RACheats\n" +
-                        "- If you believe someone is in violation of our [Global Leaderboard and Achievement Hunting Rules](https://docs.retroachievements.org/guidelines/users/global-leaderboard-and-achievement-hunting-rules.html#not-allowed)."),
-                ),
-        );
+          new TextDisplayBuilder().setContent(
+            "## :e_mail: Admins and Moderators\n" +
+              "- Reporting offensive behavior.\n" +
+              "- Reporting copyrighted material.\n" +
+              "- Requesting to be untracked.",
+          ),
+        ),
+    )
+    .addSeparatorComponents(
+      new SeparatorBuilder().setSpacing(SeparatorSpacingSize.Small).setDivider(true),
+    )
+    .addSectionComponents(
+      new SectionBuilder()
+        .setButtonAccessory(buildContactButton("DevCompliance"))
+        .addTextDisplayComponents(
+          new TextDisplayBuilder().setContent(
+            "## :e_mail: Developer Compliance\n" +
+              "- Requesting set approval or early set release.\n" +
+              "- Reporting achievements or sets with unwelcome concepts.\n" +
+              "- Reporting sets failing to cover basic progression.",
+          ),
+        ),
+    )
+    .addSeparatorComponents(
+      new SeparatorBuilder().setSpacing(SeparatorSpacingSize.Small).setDivider(true),
+    )
+    .addSectionComponents(
+      new SectionBuilder()
+        .setButtonAccessory(buildContactButton("QATeam"))
+        .addTextDisplayComponents(
+          new TextDisplayBuilder().setContent(
+            "## :e_mail: Quality Assurance\n" +
+              "- Reporting a broken set, leaderboard, or rich presence.\n" +
+              "- Reporting achievements with grammatical mistakes.\n" +
+              "- Requesting a set be playtested.\n" +
+              "- Hash compatibility questions.\n" +
+              "- Hub organizational questions.\n" +
+              "- Getting involved in a QA sub-team.",
+          ),
+        ),
+    )
+    .addSeparatorComponents(
+      new SeparatorBuilder().setSpacing(SeparatorSpacingSize.Small).setDivider(true),
+    )
+    .addSectionComponents(
+      new SectionBuilder()
+        .setButtonAccessory(buildContactButton("RAArtTeam"))
+        .addTextDisplayComponents(
+          new TextDisplayBuilder().setContent(
+            "## :e_mail: RAArtTeam\n" +
+              "- Icon Gauntlets and how to start one.\n" +
+              "- Proposing art updates.\n" +
+              "- Questions about art-related rule changes.\n" +
+              "- Requests for help with creating a new badge or badge set.",
+          ),
+        ),
+    )
+    .addSeparatorComponents(
+      new SeparatorBuilder().setSpacing(SeparatorSpacingSize.Small).setDivider(true),
+    )
+    .addSectionComponents(
+      new SectionBuilder()
+        .setButtonAccessory(buildContactButton("WritingTeam"))
+        .addTextDisplayComponents(
+          new TextDisplayBuilder().setContent(
+            "## :e_mail: WritingTeam\n" +
+              "- Submitting a Play This Set, Wish This Set, or RAdvantage entry.\n" +
+              "- Submitting a retrogaming article.\n" +
+              "- Proposing a new article idea.\n" +
+              "- Getting involved with RANews.",
+          ),
+        ),
+    )
+    .addSeparatorComponents(
+      new SeparatorBuilder().setSpacing(SeparatorSpacingSize.Small).setDivider(true),
+    )
+    .addSectionComponents(
+      new SectionBuilder()
+        .setButtonAccessory(buildContactButton("RANews"))
+        .addTextDisplayComponents(
+          new TextDisplayBuilder().setContent(
+            "## :e_mail: RANews\n" +
+              "- Submitting a Play This Set, Wish This Set, or RAdvantage entry.\n" +
+              "- Submitting a retrogaming article.\n" +
+              "- Proposing a new article idea.\n" +
+              "- Getting involved with RANews.",
+          ),
+        ),
+    )
+    .addSeparatorComponents(
+      new SeparatorBuilder().setSpacing(SeparatorSpacingSize.Small).setDivider(true),
+    )
+    .addSectionComponents(
+      new SectionBuilder()
+        .setButtonAccessory(buildContactButton("RAEvents"))
+        .addTextDisplayComponents(
+          new TextDisplayBuilder().setContent(
+            "## :e_mail: RAEvents\n" +
+              "- Submissions, questions, ideas, or reporting issues related to events.",
+          ),
+        ),
+    )
+    .addSeparatorComponents(
+      new SeparatorBuilder().setSpacing(SeparatorSpacingSize.Small).setDivider(true),
+    )
+    .addSectionComponents(
+      new SectionBuilder()
+        .setButtonAccessory(buildContactButton("DevQuest"))
+        .addTextDisplayComponents(
+          new TextDisplayBuilder().setContent(
+            "## :e_mail: DevQuest\n" +
+              "- Submissions, questions, ideas, or reporting issues related to DevQuest.",
+          ),
+        ),
+    )
+    .addSeparatorComponents(
+      new SeparatorBuilder().setSpacing(SeparatorSpacingSize.Small).setDivider(true),
+    )
+    .addSectionComponents(
+      new SectionBuilder()
+        .setButtonAccessory(buildContactButton("RACheats"))
+        .addTextDisplayComponents(
+          new TextDisplayBuilder().setContent(
+            "## :e_mail: RACheats\n" +
+              "- If you believe someone is in violation of our [Global Leaderboard and Achievement Hunting Rules](https://docs.retroachievements.org/guidelines/users/global-leaderboard-and-achievement-hunting-rules.html#not-allowed).",
+          ),
+        ),
+    );
 };


### PR DESCRIPTION
Overall roughly the same length, but looks nicer. Separators are added to improve readability, buttons are off to the side to be out of the way.

Additionally, it makes the command ephemeral so it doesn't spam the chat with how long it is. This does not affect the text based `!contact` which is always sent to chat.

This also fixes the issue with the bullet points constantly nesting.

Before:
<img width="1224" height="2362" alt="image" src="https://github.com/user-attachments/assets/2d14dc35-0782-468b-b783-f83a899f27a9" />

After:
<img width="1342" height="2854" alt="CleanShot 2026-03-16 at 21 21 19@2x" src="https://github.com/user-attachments/assets/9541694f-2008-4bf1-8dd8-3843b9e9d0b8" />

